### PR TITLE
GRPC healthcheck fixes + other minor improvements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,20 @@ ARG GOVERSION="1.24"
 ARG USERNAME=search
 FROM golang:${GOVERSION} AS dev
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.22 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.39 && \
+    wget -qO/usr/local/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /usr/local/bin/grpc_health_probe
+
+# Install Delve debugger
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 WORKDIR /src
 # ENV CGO_ENABLED=0
-COPY go.* .
+COPY go.mod .
+COPY go.sum .
 RUN go mod download
+
+ENV GOCACHE=/home/$USERNAME/.cache/go-build
 COPY cfsm ./cfsm
 COPY contract ./contract
 COPY ent ./ent
@@ -25,20 +31,29 @@ RUN --mount=type=cache,target=/home/$USERNAME/.cache/go-build \
 
 # FROM scratch AS prod
 # ENV PATH=/
-# COPY --from=dev /bin/grpc_health_probe /
+# COPY --from=dev /usr/local/bin/grpc_health_probe /
 # COPY --from=dev /usr/local/bin/middleware /
 # COPY --from=dev /usr/local/bin/broker /
 
 
 # Use Python 3.13 as base image
-FROM python:3.13 AS with-python-vfsm-bisimulation
+FROM python:3.12-slim AS with-python-vfsm-bisimulation
 ENV PYTHONUNBUFFERED=1
+# https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
+COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /uvx /bin/
+ENV UV_COMPILE_BYTECODE=1
 
 # Set working directory to /app
 WORKDIR /app
 
-RUN pip install z3-solver cfsm-bisimulation
+RUN uv pip install --system z3-solver cfsm-bisimulation
 
-COPY --from=dev /bin/grpc_health_probe /usr/local/bin/
+COPY --from=dev /usr/local/bin/grpc_health_probe /usr/local/bin/
 COPY --from=dev /usr/local/bin/middleware /usr/local/bin/
 COPY --from=dev /usr/local/bin/broker /usr/local/bin/
+
+# FROM with-python-vfsm-bisimulation AS debug
+
+# COPY --from=dev /go/bin/dlv /usr/local/bin/
+# # Copy source code for debugging
+# COPY --from=dev /src /src

--- a/examples/credit-card-payments/client-go/Dockerfile
+++ b/examples/credit-card-payments/client-go/Dockerfile
@@ -2,9 +2,9 @@ ARG GOVERSION="1.24"
 ARG USERNAME=search
 FROM golang:${GOVERSION} AS dev
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.22 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.39 && \
+    wget -qO/usr/local/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /usr/local/bin/grpc_health_probe
 
 WORKDIR /src
 

--- a/examples/credit-card-payments/docker-compose.yaml
+++ b/examples/credit-card-payments/docker-compose.yaml
@@ -71,7 +71,7 @@ services:
       - "11000"
       - "10000"
     healthcheck:
-      test: ["CMD", "/bin/grpc_health_probe", "-addr=:11000"]
+      test: ["CMD", "/usr/local/bin/grpc_health_probe", "-addr=:11000"]
       interval: 2s
       timeout: 1s
       retries: 5
@@ -88,7 +88,7 @@ services:
     depends_on:
       - broker
     healthcheck:
-      test: ["CMD", "/bin/grpc_health_probe", "-addr=:11000"]
+      test: ["CMD", "/usr/local/bin/grpc_health_probe", "-addr=:11000"]
       interval: 2s
       timeout: 1s
       retries: 5
@@ -105,7 +105,7 @@ services:
     depends_on:
       - broker
     healthcheck:
-      test: ["CMD", "/bin/grpc_health_probe", "-addr=:11000"]
+      test: ["CMD", "/usr/local/bin/grpc_health_probe", "-addr=:11000"]
       interval: 2s
       timeout: 1s
       retries: 5

--- a/examples/credit-card-payments/docker-compose.yaml
+++ b/examples/credit-card-payments/docker-compose.yaml
@@ -6,7 +6,8 @@ services:
     networks:
       - backend_network
     depends_on:
-      - middleware-backend
+      middleware-backend:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "/usr/bin/stat", "/tmp/registered"]
       interval: 2s
@@ -32,9 +33,12 @@ services:
     networks:
       - client_network
     depends_on:
-      - middleware-client
-      - backend
-      - payments-service
+      middleware-client:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
+      payments-service:
+        condition: service_healthy
 
   payments-service:
     build:
@@ -43,7 +47,8 @@ services:
     networks:
       - payments_network
     depends_on:
-      - middleware-payments-service
+      middleware-payments-service:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "/usr/bin/stat", "/tmp/registered"]
       interval: 2s
@@ -56,6 +61,12 @@ services:
     networks:
       - broker_network
     command: ["broker"]
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/grpc_health_probe", "-addr=:10000"]
+      interval: 1s
+      timeout: 1s
+      retries: 5
+      start_period: 1s
 
   middleware-backend:
     build: ../../
@@ -66,7 +77,8 @@ services:
       - SERVICE_NAME=backend
     command: "middleware -broker_addr broker:10000 -private_host 0.0.0.0 -public_url middleware-backend:10000"
     depends_on:
-      - broker
+      broker:
+        condition: service_healthy
     expose:
       - "11000"
       - "10000"
@@ -86,7 +98,8 @@ services:
       - SERVICE_NAME=client
     command: "middleware -broker_addr broker:10000 -private_host 0.0.0.0 -public_url middleware-client:10000"
     depends_on:
-      - broker
+      broker:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "/usr/local/bin/grpc_health_probe", "-addr=:11000"]
       interval: 2s
@@ -103,7 +116,8 @@ services:
       - SERVICE_NAME=payments-service
     command: "middleware -broker_addr broker:10000 -private_host 0.0.0.0 -public_url middleware-payments-service:10000"
     depends_on:
-      - broker
+      broker:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "/usr/local/bin/grpc_health_probe", "-addr=:11000"]
       interval: 2s

--- a/examples/credit-card-payments/payments-service/Dockerfile
+++ b/examples/credit-card-payments/payments-service/Dockerfile
@@ -2,9 +2,9 @@ ARG GOVERSION="1.24"
 ARG USERNAME=search
 FROM golang:${GOVERSION} AS dev
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.22 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.39 && \
+    wget -qO/usr/local/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /usr/local/bin/grpc_health_probe
 
 WORKDIR /src
 # ENV CGO_ENABLED=0

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -760,7 +760,7 @@ func (s *brokerServer) StartServer(address string, tls bool, certFile string, ke
 	s.server = grpcServer
 	pb.RegisterBrokerServiceServer(grpcServer, s)
 
-	// Registrar el servicio de health check
+	// Register GRPC health check service.
 	healthServer := health.NewServer()
 	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	healthpb.RegisterHealthServer(grpcServer, healthServer)

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -19,6 +19,8 @@ import (
 	"github.com/sourcegraph/conc/iter"
 	"github.com/sourcegraph/conc/pool"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -757,6 +759,12 @@ func (s *brokerServer) StartServer(address string, tls bool, certFile string, ke
 	grpcServer := grpc.NewServer(opts...)
 	s.server = grpcServer
 	pb.RegisterBrokerServiceServer(grpcServer, s)
+
+	// Registrar el servicio de health check
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
+
 	s.logger.Printf("Broker server starting...")
 	if notifyStartChan != nil {
 		s.logger.Print("Sending broker public URL to notifyStartChan...")

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -643,3 +643,174 @@ func TestBisimulationPython(t *testing.T) {
 	}
 
 }
+
+// New functional test where we do the following:
+// 1. Register provider Monitor with the following contract:
+const monitor_contract = `
+.outputs Monitor
+.state graph
+0 ImgP ? stop 2
+0 ImgP ! allFine 0
+0 ImgP ! attack 3
+.marking 0
+.end
+`
+
+// 2. Register provider ImgP with the following contract:
+const imgp_contract = `
+.outputs ImgP
+.state graph
+0 2 ? req 4
+0 2 ? stop 2
+2 1 ! stop 8
+4 1 ? allFine 5
+4 1 ? attack 6
+5 2 ! img 0
+6 2 ! attack 7
+.marking 0
+.end
+`
+
+// 3. Send a request to the broker with the following global contract:
+const webui_contract = `
+.outputs ImgP
+.state graph
+0 WebUI ? req 4
+0 WebUI ? stop 2
+2 Monitor ! stop 8
+4 Monitor ? allFine 5
+4 Monitor ? attack 6
+5 WebUI ! img 0
+6 WebUI ! attack 7
+.marking 0
+.end
+
+
+.outputs Monitor
+.state graph
+0 ImgP ? stop 2
+0 ImgP ! allFine 0
+0 ImgP ! attack 3
+.marking 0
+.end
+
+
+.outputs WebUI
+.state graph
+0 ImgP ! req 5
+0 ImgP ! stop 3
+5 ImgP ? attack 6
+5 ImgP ? img 0
+.marking 0
+.end
+`
+
+func TestParticipantMapping(t *testing.T) {
+	// Arrange
+	testDir := t.TempDir()
+	b := NewBrokerServer(fmt.Sprintf("%s/t.db", testDir))
+	t.Cleanup(b.Stop)
+
+	// Register Monitor provider
+	monitorContract, err := contract.ConvertPBLocalContract(
+		&pb.LocalContract{
+			Contract: []byte(monitor_contract),
+			Format:   pb.LocalContractFormat_LOCAL_CONTRACT_FORMAT_FSA,
+		},
+	)
+	if err != nil {
+		t.Fatalf("error converting monitor contract: %v", err)
+	}
+
+	monitorRegisteredContract, err := b.getOrSaveContract(context.Background(), monitorContract)
+	if err != nil {
+		t.Fatalf("error saving monitor contract: %v", err)
+	}
+	monitorAppID := uuid.New()
+	monitorUrl, _ := url.Parse("monitor.example.org:8080")
+	_, err = b.saveProvider(context.TODO(), monitorAppID, monitorUrl, monitorRegisteredContract)
+	if err != nil {
+		t.Fatalf("error saving monitor provider: %v", err)
+	}
+
+	// Register ImgP provider
+	imgpContract, err := contract.ConvertPBLocalContract(
+		&pb.LocalContract{
+			Contract: []byte(imgp_contract),
+			Format:   pb.LocalContractFormat_LOCAL_CONTRACT_FORMAT_FSA,
+		},
+	)
+	if err != nil {
+		t.Fatalf("error converting imgp contract: %v", err)
+	}
+
+	imgpRegisteredContract, err := b.getOrSaveContract(context.Background(), imgpContract)
+	if err != nil {
+		t.Fatalf("error saving imgp contract: %v", err)
+	}
+	imgpAppID := uuid.New()
+	imgpUrl, _ := url.Parse("imgp.example.org:8080")
+	_, err = b.saveProvider(context.TODO(), imgpAppID, imgpUrl, imgpRegisteredContract)
+	if err != nil {
+		t.Fatalf("error saving imgp provider: %v", err)
+	}
+
+	// Create global contract request
+	globalContract, err := contract.ConvertPBGlobalContract(
+		&pb.GlobalContract{
+			Contract:      []byte(webui_contract),
+			Format:        pb.GlobalContractFormat_GLOBAL_CONTRACT_FORMAT_FSA,
+			InitiatorName: "ImgP", // Starting with ImgP as initiator
+		},
+	)
+	if err != nil {
+		t.Fatalf("error converting global contract: %v", err)
+	}
+
+	// Test participant mapping for ImgP
+	imgpProjection, err := globalContract.GetProjection("ImgP")
+	if err != nil {
+		t.Fatalf("error getting ImgP projection: %v", err)
+	}
+
+	imgpRes, imgpMapping, err := BisimilarityAlgorithm(context.Background(), imgpProjection, imgpContract)
+	if err != nil {
+		t.Fatalf("error running bisimilarity algorithm for ImgP: %v", err)
+	}
+	if !imgpRes {
+		t.Fatal("ImgP contracts are not bisimilar")
+	}
+
+	// Verify ImgP mappings
+	expectedImgpMappings := map[string]string{
+		"WebUI":   "2",
+		"Monitor": "1",
+	}
+	for participant, mapping := range expectedImgpMappings {
+		if got := imgpMapping[participant]; got != mapping {
+			t.Errorf("ImgP mapping for %s = %s; want %s", participant, got, mapping)
+		}
+	}
+
+	// Test participant mapping for Monitor
+	monitorProjection, err := globalContract.GetProjection("Monitor")
+	if err != nil {
+		t.Fatalf("error getting Monitor projection: %v", err)
+	}
+
+	monitorRes, monitorMapping, err := BisimilarityAlgorithm(context.Background(), monitorProjection, monitorContract)
+	if err != nil {
+		t.Fatalf("error running bisimilarity algorithm for Monitor: %v", err)
+	}
+	if !monitorRes {
+		t.Fatal("Monitor contracts are not bisimilar")
+	}
+
+	// Verify Monitor mappings
+	if len(monitorMapping) != 1 {
+		t.Errorf("Monitor mapping has %d entries; want 1", len(monitorMapping))
+	}
+	if got := monitorMapping["ImgP"]; got != "ImgP" {
+		t.Errorf("Monitor mapping for ImgP = %s; want ImgP", got)
+	}
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -22,6 +22,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/testdata"
 
@@ -532,20 +534,16 @@ func (s *MiddlewareServer) MessageExchange(stream pb.PublicMiddlewareService_Mes
 		s.logger.Printf("Error in MessageExchange when attempting to recv from stream: %s", err)
 		return err // TODO: what should we do here?
 	}
-	s.logger.Print("[DEBUG] Attempting to obtain channelLock...")
 	s.channelLock.RLock()
-	s.logger.Print("[DEBUG] Obtained the channelLock...")
 	c, ok := s.brokeredChannels[in.GetChannelId()]
 	if !ok {
 		// TODO: attempt to get the channel from s.brokeringChannels (this can happen when some provider starts sending messages to the Service Client
 		// before we have finished processing the BrokerChannelResponse)
 		s.logger.Printf("Received MessageExchange with ChannelID %s but it is not a brokered Channel in this middleware.", in.GetChannelId())
 		s.channelLock.RUnlock()
-		s.logger.Print("[DEBUG] Released channelLock...")
 		return fmt.Errorf("Received MessageExchange with ChannelID %s but it is not a brokered Channel in this middleware.", in.GetChannelId())
 	}
 	s.channelLock.RUnlock()
-	s.logger.Print("[DEBUG] Released channelLock...")
 	// TODO: must check in.RecipientId... we could be hosting two different apps from same channel
 	participantName := c.participants[in.SenderId]
 
@@ -693,6 +691,12 @@ func (s *MiddlewareServer) StartMiddlewareServer(wg *sync.WaitGroup, publicURL s
 
 	s.publicServer = publicGrpcServer
 	s.privateServer = privateGrpcServer
+
+	// Register GRPC healthcheck service on both servers.
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(publicGrpcServer, healthServer)
+	healthpb.RegisterHealthServer(privateGrpcServer, healthServer)
 
 	pb.RegisterPublicMiddlewareServiceServer(publicGrpcServer, s)
 	pb.RegisterPrivateMiddlewareServiceServer(privateGrpcServer, s)


### PR DESCRIPTION
- Upgrade grpc-health-probe to v0.4.39
- Fix grpc-health-probe path
- Install Delve debugger in the container image
- Use GOCACHE in container image build process
- Use astral-sh/uv when installing cfsm-bisimulation for faster build time
- Add GRPC health check server to broker and middleware
- Add new functional test
- Remove noisy logs related to channelLock in middleware